### PR TITLE
Update config name, change time zone

### DIFF
--- a/neo/detector/apps.py
+++ b/neo/detector/apps.py
@@ -1,4 +1,4 @@
 from django.apps import AppConfig
 
-class DisplayConfig(AppConfig):
+class DetectorConfig(AppConfig):
     name = 'detector'

--- a/neo/settings.py
+++ b/neo/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'detector.apps.DetectorConfig',
+    # 'detector.apps.DetectorConfig',
 ]
 
 MIDDLEWARE = [
@@ -110,7 +110,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 
 USE_I18N = True
 


### PR DESCRIPTION
* Update config name from DisplayConfig to DetectorConfig in apps.py
* Remove detector.apps.DetectorConfig from INSTALLED_APPS, causing
migration errors
* Update time zone from UTC to America/New_York